### PR TITLE
Revert "more text filter stuff (#1118)"

### DIFF
--- a/code/__HELPERS/text_filter.dm
+++ b/code/__HELPERS/text_filter.dm
@@ -3,15 +3,15 @@ GLOBAL_DATUM_INIT(text_filter_datum, /datum/text_filter, new)
 /datum/text_filter
 	//used for some text operations that need to hold a bunch of regexes or whatever in memory
 	//probably not the best way to do it, but globals are bad
-	var/list/regex/regexes = list()
+	var/static/regex/reeegex = new(@"\b[Rr]+[Ee]{2,}\b")
+	var/static/regex/yeetgex = new(@"\b[Yy]+[Ee]{2,}[Tt]+([Ee][Dd])?([Ii][Nn][Gg])?\b")
 
-/datum/text_filter/New()
-	var/list/raw_regexes = world.file2list("strings/retard_regex.txt")
-	for(var/r in raw_regexes)
-		var/regex/tmp = new(r)
-		regexes += tmp
+/datum/text_filter/proc/ree_check(message)
+	if(reeegex.Find(message))
+		return TRUE
+	return FALSE
 
-/datum/text_filter/proc/do_checks(message)
-	for(var/regex/r  in regexes)
-		if(r.Find(message))
-			return TRUE
+/datum/text_filter/proc/yeet_check(message)
+	if(yeetgex.Find(message))
+		return TRUE
+	return FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -503,5 +503,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		//add more stuff to the switch if you have more blood colors for different types
 
 /proc/check_retard_speech(message = "")
-	if(GLOB.text_filter_datum.do_checks(message))
+	if(GLOB.text_filter_datum.ree_check(message))
+		return TRUE
+	if(GLOB.text_filter_datum.yeet_check(message))
 		return TRUE

--- a/strings/retard_regex.txt
+++ b/strings/retard_regex.txt
@@ -1,4 +1,0 @@
-\b[Rr]+[Ee]{2,}\b
-\b[Yy]+[Ee]{2,}[Tt]+([Ee][Dd])?([Ii][Nn][Gg])?\b
-\b[Nn][Ii][Gg]{2,}[Aa]?[Ee]?[Rr]?[Ss]?[Zz]?\b
-\b[Ff][Aa][Gg]{2,}[Oo][Tt]\b


### PR DESCRIPTION
This reverts commit 3ca2bf81d40d0ebb6b2dff9bb7643b0a53943921.


:cl: optional name here
add: nword
/:cl:

### What: Removes text filter
### Why: Because that's literally why wasp was formed